### PR TITLE
Load docs from VTKBase.jl package

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+VTKBase = "4004b06d-e244-455f-a6ce-a5f9919cc534"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,3 +6,4 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 Documenter = "0.27"
+VTKBase = "1.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,17 +1,39 @@
+using VTKBase
 using WriteVTK
 using Documenter
 
 DocMeta.setdocmeta!(
+    VTKBase, :DocTestSetup,
+    quote
+        using VTKBase
+    end;
+    recursive = true,
+)
+
+DocMeta.setdocmeta!(
     WriteVTK, :DocTestSetup,
     quote
+        using VTKBase
         using WriteVTK
         using StaticArrays  # not yet used...
     end;
     recursive = true,
 )
 
+# Path to markdown file containing docs for VTKBase.jl
+# We copy the file to src/external/
+vtkbase_docs_src = joinpath(
+    dirname(dirname(pathof(VTKBase))),  # VTKBase directory
+    "docs",
+    "src",
+    "VTKBase.md",
+)
+isfile(vtkbase_docs_src) || error("file not found: $vtkbase_docs_src")
+vtkbase_docs = joinpath("external", "VTKBase.md")
+cp(vtkbase_docs_src, joinpath(@__DIR__, "src", vtkbase_docs); force = true)
+
 makedocs(;
-    modules = [WriteVTK],
+    modules = [VTKBase, WriteVTK],
     authors = "Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr> and contributors",
     repo = "https://github.com/JuliaVTK/WriteVTK.jl/blob/{commit}{path}#L{line}",
     sitename = "WriteVTK.jl",
@@ -23,7 +45,7 @@ makedocs(;
         ],
         mathengine = KaTeX(),
     ),
-    pages=[
+    pages = [
         "Home" => "index.md",
         "Grid formats" => [
             "grids/syntax.md",
@@ -42,6 +64,7 @@ makedocs(;
             "tools/readvtk.md",
         ],
         "API Reference" => "API.md",
+        "VTKBase.jl" => vtkbase_docs,
     ],
 )
 

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -11,15 +11,3 @@ Pages = ["API.md"]
 ```@autodocs
 Modules = [WriteVTK]
 ```
-
-## VTKCellTypes
-
-```@autodocs
-Modules = [VTKCellTypes]
-```
-
-## PolyData
-
-```@autodocs
-Modules = [PolyData]
-```

--- a/docs/src/external/.gitignore
+++ b/docs/src/external/.gitignore
@@ -1,0 +1,2 @@
+# Files in this directory are "generated" by make.jl
+*.md


### PR DESCRIPTION
Requires VTKBase.jl v1.0, which includes the `docs/src/VTKBase.md` file.