### PR TITLE
Updated links to VTK specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In each case, the correct kind of VTK file will be generated.
 ## Supported VTK formats
 
 This package attempts to implement writers for all VTK XML formats described in
-the [VTK specification](http://www.vtk.org/VTK/img/file-formats.pdf).
+the [VTK specification](https://docs.vtk.org/en/latest/design_documents/VTKFileFormats.html).
 Note that legacy (non-XML) files are not supported.
 
 Supported dataset formats include:

--- a/docs/src/grids/unstructured.md
+++ b/docs/src/grids/unstructured.md
@@ -46,7 +46,7 @@ Note that, since this is a triangle, the connectivity vector *must* contain thre
 ## Unstructured grid
 
 The cell types available for the unstructured grid format are those listed in the
-[VTK specification](http://www.vtk.org/VTK/img/file-formats.pdf) (figures 2 and 3).
+[VTK specification](https://docs.vtk.org/en/latest/design_documents/VTKFileFormats.html) (figures 2 and 3).
 For convenience, WriteVTK includes a [`VTKCellTypes`](@ref) module that contains
 these definitions.
 For instance, a triangle is associated to the cell type `VTKCellTypes.VTK_TRIANGLE`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,7 +53,7 @@ In each case, the correct kind of VTK file will be generated.
 ## Supported VTK formats
 
 This package attempts to implement writers for all VTK XML formats described in
-the [VTK specification](http://www.vtk.org/VTK/img/file-formats.pdf).
+the [VTK specification](https://docs.vtk.org/en/latest/design_documents/VTKFileFormats.html).
 Note that legacy (non-XML) files are not supported.
 
 Supported dataset formats include:


### PR DESCRIPTION
Links to the VTK specification point to a page that does not exist any more:

http://www.vtk.org/VTK/img/file-formats.pdf

These links appear in:
1. The README (https://github.com/JuliaVTK/WriteVTK.jl/blob/d15119c2638b738437e2dd1c1787edfc541b9284/README.md?plain=1#L63)
2. The documentation index page (https://github.com/JuliaVTK/WriteVTK.jl/blob/d15119c2638b738437e2dd1c1787edfc541b9284/docs/src/index.md?plain=1#L56), and
3. The documentation for unstructured grids (https://github.com/JuliaVTK/WriteVTK.jl/blob/d15119c2638b738437e2dd1c1787edfc541b9284/docs/src/grids/unstructured.md?plain=1#L49)

I have replaced these links with the new appropriate link to the VTK specification in the documentation:

https://docs.vtk.org/en/latest/design_documents/VTKFileFormats.html