### PR TITLE
 Relative path to .vtu in .pvtu files

### DIFF
--- a/src/gridtypes/pvtk_grid.jl
+++ b/src/gridtypes/pvtk_grid.jl
@@ -207,14 +207,13 @@ end
 # Here `path` is the basename of the main pvtk file (without the extension).
 # Note that it can be in a subdirectory of `.`, and it can either be an absolute or relative
 # path.
-# If it is an absolute value, then always return an absolute value.
 function _pvtk_vtk_filename_prefix(path; relative_to_pvtk, create_dirs = false)
     dir_serial = path  # directory where serial files will be written
     if create_dirs
         mkpath(dir_serial)
     end
     bname = basename(path)
-    if isabspath(path) || !relative_to_pvtk
+    if !relative_to_pvtk
         joinpath(dir_serial, bname)
     else
         _, reldir = splitdir(dir_serial)


### PR DESCRIPTION
This PR intends to replace absolute paths in `.pvtu` files by relative paths, as described in #151.

I wrote the truth table of the `if` block in `pvtk_grid._pvtk_vtk_filename_prefix` and it seems to me that what we want is simply `if !relative_to_pvtk (...) else (...)`. At least the tests I've ran are ok.