### PR TITLE
Fix memory leak

### DIFF
--- a/src/gridtypes/ParaviewCollection.jl
+++ b/src/gridtypes/ParaviewCollection.jl
@@ -56,6 +56,7 @@ function paraview_collection_load(filename::AbstractString)
         set_attribute(xDataSet, "part", attribute(c, "part"))
         set_attribute(xDataSet, "file", attribute(c, "file"))
     end
+    LightXML.free(xpvd)
     return pvd
 end
 


### PR DESCRIPTION
We found that not freeing xpvd caused a memory leak in our simulations in which we append to the collection in every write step.