### PR TITLE
Implement thread-parallel compression for `vtk_grid`

### DIFF
--- a/docs/src/grids/syntax.md
+++ b/docs/src/grids/syntax.md
@@ -64,7 +64,7 @@ More generally:
   This option is ignored when writing inline data in ASCII format.
 
 - If `parallel_compression` is `true`, appended compressed data may be split into
-  VTK compression blocks and compressed using Julia threads.
+  VTK compression blocks and compressed in parallel using Julia threads.
   This is disabled by default and only applies to dense arrays with bitstype
   elements. Other data falls back to serial compression.
 
@@ -102,4 +102,3 @@ The `vtkversion` argument can take the following values:
 VTK file version `1.0` is used by default for backwards compatibility and to
 make sure that the generated files can be read by old versions of the VTK
 libraries and of ParaView.
-

--- a/docs/src/grids/syntax.md
+++ b/docs/src/grids/syntax.md
@@ -63,6 +63,11 @@ More generally:
   and 9 (best compression).
   This option is ignored when writing inline data in ASCII format.
 
+- If `parallel_compression` is `true`, appended compressed data may be split into
+  VTK compression blocks and compressed using Julia threads.
+  This is disabled by default and only applies to dense arrays with bitstype
+  elements. Other data falls back to serial compression.
+
 ## Setting the VTK file version
 
 The `vtk_grid` function also allows setting the VTK file version using the optional `vtkversion` keyword argument.

--- a/src/WriteVTK.jl
+++ b/src/WriteVTK.jl
@@ -72,16 +72,18 @@ struct DatasetFile <: VTKFile
     xdoc::XMLDocument
     path::String
     grid_type::String
-    version::String     # VTK XML file version
-    Npts::Int           # Number of grid points.
-    Ncls::Int           # Number of cells.
-    compression_level::Int  # Compression level for zlib (if 0, compression is disabled)
-    appended::Bool      # Data is appended? (otherwise it's written inline, base64-encoded)
-    ascii::Bool         # if true, inline data is written in ASCII format (only used if `appended` is false)
-    buf::IOBuffer       # Buffer with appended data.
+    version::String             # VTK XML file version
+    Npts::Int                   # Number of grid points.
+    Ncls::Int                   # Number of cells.
+    compression_level::Int      # Compression level for zlib (if 0, compression is disabled)
+    parallel_compression::Bool  # Compress appended data blocks in parallel?
+    appended::Bool              # Data is appended? (otherwise it's written inline, base64-encoded)
+    ascii::Bool                 # if true, inline data is written in ASCII format (only used if `appended` is false)
+    buf::IOBuffer               # Buffer with appended data.
     function DatasetFile(
             xdoc, path, grid_type, Npts, Ncls;
             compress=true, append=true, ascii=false,
+            parallel_compression=false,
             vtkversion = :default,
         )
         clevel = _compression_level(compress)
@@ -98,7 +100,8 @@ struct DatasetFile <: VTKFile
             close(buf)
         end
         version = vtk_version(vtkversion)
-        new(xdoc, path, grid_type, version, Npts, Ncls, clevel, append, ascii, buf)
+        new(xdoc, path, grid_type, version, Npts, Ncls, clevel,
+            parallel_compression, append, ascii, buf)
     end
 end
 

--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -125,21 +125,21 @@ function _compression_block_size(nbytes)
     # Produce many blocks as soon as possible for small files while avoiding tiny blocks
     # to allow for efficient multithreading even for small files (~1 MiB).
     # Then scale up block size to a reasonable 1MiB, then again increase block size
-    # until 1000 blocks to get good scaling for huge CPUs.
-    # After reaching 1000 blocks, cap it at that and increase block size.
+    # until 1024 blocks to get good scaling for huge CPUs.
+    # After reaching 1024 blocks, cap it at that and increase block size.
     #
     # | Input Size | Block Size | Number of Blocks |
     # |     2 MiB  |   128 KiB  |              16  |
-    # |    25 MiB  |   256 KiB  |             100  |
-    # |   100 MiB  |     1 MiB  |             100  |
-    # |     1 GiB  |    ~1 MiB  |           ~1000  |
-    # |   100 GiB  |  ~102 MiB  |            1000  |
-    if nbytes < 100MiB
-        # For small files, target 100 blocks but use minimum block size of 128 KiB.
-        max(cld(nbytes, 100), 128KiB)
+    # |    16 MiB  |   128 KiB  |             128  |
+    # |   128 MiB  |     1 MiB  |             128  |
+    # |     1 GiB  |     1 MiB  |            1024  |
+    # |   100 GiB  |   100 MiB  |            1024  |
+    if nbytes < 128MiB
+        # For small files, target 128 blocks but use minimum block size of 128 KiB.
+        max(cld(nbytes, 128), 128KiB)
     else
-        # For large files, target 1000 blocks but use minimum block size of 1 MiB.
-        max(cld(nbytes, 1000), 1MiB)
+        # For large files, target 1024 blocks but use minimum block size of 1 MiB.
+        max(cld(nbytes, 1024), 1MiB)
     end
 end
 

--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -110,15 +110,38 @@ function write_array(io, data::Tuple)
     n
 end
 
-nthreads() = Threads.nthreads() # Function to mock the number of threads in tests.
-const VTK_COMPRESSION_BLOCKS_PER_THREAD = 4
-const VTK_COMPRESSION_MIN_BLOCK_BYTES = 256^2 # 64 KiB
-
 function _can_compress_in_parallel(data::AbstractArray{T}) where {T}
     # Only dense bitstype arrays can be split into VTK compression blocks in a useful way.
-    data isa DenseArray && isbitstype(T) && !isempty(data) && nthreads() > 1
+    data isa DenseArray && isbitstype(T) && !isempty(data)
 end
 _can_compress_in_parallel(data) = false
+
+function _compression_block_size(nbytes)
+    KiB = 1024
+    MiB = 1024 * KiB
+
+    # To produce hardware-independent output files, choose block size based on input
+    # size, not on the number of threads.
+    # Produce many blocks as soon as possible for small files while avoiding tiny blocks
+    # to allow for efficient multithreading even for small files (~1 MiB).
+    # Then scale up block size to a reasonable 1MiB, then again increase block size
+    # until 1000 blocks to get good scaling for huge CPUs.
+    # After reaching 1000 blocks, cap it at that and increase block size.
+    #
+    # | Input Size | Block Size | Number of Blocks |
+    # |     2 MiB  |   128 KiB  |              16  |
+    # |    25 MiB  |   256 KiB  |             100  |
+    # |   100 MiB  |     1 MiB  |             100  |
+    # |     1 GiB  |    ~1 MiB  |           ~1000  |
+    # |   100 GiB  |  ~102 MiB  |            1000  |
+    if nbytes < 100MiB
+        # For small files, target 100 blocks but use minimum block size of 128 KiB.
+        max(cld(nbytes, 100), 128KiB)
+    else
+        # For large files, target 1000 blocks but use minimum block size of 1 MiB.
+        max(cld(nbytes, 1000), 1MiB)
+    end
+end
 
 function _compressed_blocks(data::DenseArray{T}, compression_level) where {T}
     # Store compressed arrays as independently compressed blocks with an
@@ -128,18 +151,9 @@ function _compressed_blocks(data::DenseArray{T}, compression_level) where {T}
     data_vec = vec(data)
     num_elements = length(data_vec)
     bytes_per_element = sizeof(T)
+    nbytes = num_elements * bytes_per_element
 
-    # Aim for multiple blocks per threads to reduce variance in runtime between threads.
-    target_num_blocks = min(num_elements,
-                            VTK_COMPRESSION_BLOCKS_PER_THREAD * nthreads())
-
-    elements_per_block = cld(num_elements, target_num_blocks)
-
-    # Avoid absurdly small blocks that would lead to inefficient compression
-    # and inefficient multi-threading.
-    min_elements = max(1, cld(VTK_COMPRESSION_MIN_BLOCK_BYTES, bytes_per_element))
-
-    elements_per_block = max(elements_per_block, min_elements)
+    elements_per_block = cld(_compression_block_size(nbytes), bytes_per_element)
     num_blocks = cld(num_elements, elements_per_block)
 
     blocks = Vector{Vector{UInt8}}(undef, num_blocks)

--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -329,8 +329,6 @@ function data_to_xml_appended(vtk::DatasetFile, xDA::XMLElement, data)
     nb = sizeof_data(data)
 
     if compress && vtk.parallel_compression && _can_compress_in_parallel(data)
-        # Parallel compression is opt-in because it changes the compressed block
-        # layout and is only valid for data that can be split byte-for-byte.
         _write_compressed_parallel(buf, data, vtk.compression_level)
     elseif compress
         _write_compressed_serial(buf, data, vtk.compression_level, nb)

--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -110,13 +110,13 @@ function write_array(io, data::Tuple)
     n
 end
 
+nthreads() = Threads.nthreads() # Function to mock the number of threads in tests.
 const VTK_COMPRESSION_BLOCKS_PER_THREAD = 4
-const VTK_COMPRESSION_MIN_BLOCK_BYTES = 256^2      # 64 KiB
-const VTK_COMPRESSION_MAX_BLOCK_BYTES = 4 * 1024^2 # 4 MiB
+const VTK_COMPRESSION_MIN_BLOCK_BYTES = 256^2 # 64 KiB
 
 function _can_compress_in_parallel(data::AbstractArray{T}) where {T}
     # Only dense bitstype arrays can be split into VTK compression blocks in a useful way.
-    data isa DenseArray && isbitstype(T) && !isempty(data)
+    data isa DenseArray && isbitstype(T) && !isempty(data) && nthreads() > 1
 end
 _can_compress_in_parallel(data) = false
 
@@ -131,16 +131,15 @@ function _compressed_blocks(data::DenseArray{T}, compression_level) where {T}
 
     # Aim for multiple blocks per threads to reduce variance in runtime between threads.
     target_num_blocks = min(num_elements,
-                            VTK_COMPRESSION_BLOCKS_PER_THREAD * Threads.nthreads())
+                            VTK_COMPRESSION_BLOCKS_PER_THREAD * nthreads())
 
     elements_per_block = cld(num_elements, target_num_blocks)
 
-    # Avoid absurdly small or large blocks that would lead to inefficient compression
-    # or inefficient multi-threading.
+    # Avoid absurdly small blocks that would lead to inefficient compression
+    # and inefficient multi-threading.
     min_elements = max(1, cld(VTK_COMPRESSION_MIN_BLOCK_BYTES, bytes_per_element))
-    max_elements = max(1, div(VTK_COMPRESSION_MAX_BLOCK_BYTES, bytes_per_element))
 
-    elements_per_block = clamp(elements_per_block, min_elements, max_elements)
+    elements_per_block = max(elements_per_block, min_elements)
     num_blocks = cld(num_elements, elements_per_block)
 
     blocks = Vector{Vector{UInt8}}(undef, num_blocks)

--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -110,6 +110,83 @@ function write_array(io, data::Tuple)
     n
 end
 
+const VTK_COMPRESSION_BLOCK_SIZE = 1024^2
+
+function _can_compress_in_parallel(data::AbstractArray{T}) where {T}
+    # Only dense bitstype arrays can be split into VTK compression blocks
+    # without changing the binary representation written by `write_array`.
+    data isa DenseArray && isbitstype(T) && !isempty(data)
+end
+_can_compress_in_parallel(data) = false
+
+function _compressed_blocks(data::DenseArray{T}, compression_level) where {T}
+    # Store compressed arrays as independently compressed blocks with an
+    # uncompressed header containing all block sizes. Each thread can therefore
+    # compress one block into a private buffer, while the final write stays
+    # serial to preserve the expected block order.
+    # TODO add more comments
+    data_vec = vec(data)
+    num_elements = length(data_vec)
+    bytes_per_element = sizeof(T)
+    elements_per_block = max(1, div(VTK_COMPRESSION_BLOCK_SIZE, bytes_per_element))
+    num_blocks = cld(num_elements, elements_per_block)
+
+    blocks = Vector{Vector{UInt8}}(undef, num_blocks)
+    Threads.@threads for block in 1:num_blocks
+        first_element = firstindex(data_vec) + (block - 1) * elements_per_block
+        last_element = min(lastindex(data_vec), first_element + elements_per_block - 1)
+        buf = IOBuffer()
+        zWriter = ZlibCompressorStream(buf, level=compression_level, stop_on_end=true)
+        write_array(zWriter, @view data_vec[first_element:last_element])
+        write(zWriter, TranscodingStreams.TOKEN_END)
+        close(zWriter)
+        blocks[block] = take!(buf)
+        close(buf)
+    end
+
+    blocksize = elements_per_block * bytes_per_element
+    last_blocksize = (num_elements - (num_blocks - 1) * elements_per_block) *
+                     bytes_per_element
+
+    return blocks, blocksize, last_blocksize
+end
+
+function _write_compressed_parallel(buf, data::DenseArray, compression_level)
+    blocks, blocksize, last_blocksize = _compressed_blocks(data, compression_level)
+    header = HeaderType.((length(blocks), blocksize, last_blocksize,
+                          length.(blocks)...))
+    write(buf, header...)
+    foreach(block -> write(buf, block), blocks)
+
+    nothing
+end
+
+function _write_compressed_serial(buf, data, compression_level, nb)
+    initpos = position(buf)
+
+    # Write temporary data that will be replaced later with the real header.
+    let header = ntuple(d -> zero(HeaderType), Val(4))
+        write(buf, header...)
+    end
+
+    # Write compressed data.
+    zWriter = ZlibCompressorStream(buf, level=compression_level, stop_on_end=true)
+    write_array(zWriter, data)
+    write(zWriter, TranscodingStreams.TOKEN_END)
+    close(zWriter) # Release allocated resources (issue #43)
+
+    # Go back to `initpos` and write real header.
+    endpos = position(buf)
+    compbytes = endpos - initpos - 4 * sizeof(HeaderType)
+    let header = HeaderType.((1, nb, nb, compbytes))
+        seek(buf, initpos)
+        write(buf, header...)
+        seek(buf, endpos)
+    end
+
+    nothing
+end
+
 function add_data_ascii(xml, x::Union{Number,AbstractString})
     add_text(xml, " ")
     add_text(xml, string(x))
@@ -228,28 +305,12 @@ function data_to_xml_appended(vtk::DatasetFile, xDA::XMLElement, data)
     # Size of data array (in bytes).
     nb = sizeof_data(data)
 
-    if compress
-        initpos = position(buf)
-
-        # Write temporary data that will be replaced later with the real header.
-        let header = ntuple(d -> zero(HeaderType), Val(4))
-            write(buf, header...)
-        end
-
-        # Write compressed data.
-        zWriter = ZlibCompressorStream(buf, level=vtk.compression_level, stop_on_end=true)
-        write_array(zWriter, data)
-        write(zWriter, TranscodingStreams.TOKEN_END)
-        close(zWriter) # Release allocated resources (issue #43)
-
-        # Go back to `initpos` and write real header.
-        endpos = position(buf)
-        compbytes = endpos - initpos - 4 * sizeof(HeaderType)
-        let header = HeaderType.((1, nb, nb, compbytes))
-            seek(buf, initpos)
-            write(buf, header...)
-            seek(buf, endpos)
-        end
+    if compress && vtk.parallel_compression && _can_compress_in_parallel(data)
+        # Parallel compression is opt-in because it changes the compressed block
+        # layout and is only valid for data that can be split byte-for-byte.
+        _write_compressed_parallel(buf, data, vtk.compression_level)
+    elseif compress
+        _write_compressed_serial(buf, data, vtk.compression_level, nb)
     else
         write(buf, HeaderType(nb))  # header (uncompressed version)
         nb_write = write_array(buf, data)

--- a/src/write_data.jl
+++ b/src/write_data.jl
@@ -110,11 +110,12 @@ function write_array(io, data::Tuple)
     n
 end
 
-const VTK_COMPRESSION_BLOCK_SIZE = 1024^2
+const VTK_COMPRESSION_BLOCKS_PER_THREAD = 4
+const VTK_COMPRESSION_MIN_BLOCK_BYTES = 256^2      # 64 KiB
+const VTK_COMPRESSION_MAX_BLOCK_BYTES = 4 * 1024^2 # 4 MiB
 
 function _can_compress_in_parallel(data::AbstractArray{T}) where {T}
-    # Only dense bitstype arrays can be split into VTK compression blocks
-    # without changing the binary representation written by `write_array`.
+    # Only dense bitstype arrays can be split into VTK compression blocks in a useful way.
     data isa DenseArray && isbitstype(T) && !isempty(data)
 end
 _can_compress_in_parallel(data) = false
@@ -124,22 +125,39 @@ function _compressed_blocks(data::DenseArray{T}, compression_level) where {T}
     # uncompressed header containing all block sizes. Each thread can therefore
     # compress one block into a private buffer, while the final write stays
     # serial to preserve the expected block order.
-    # TODO add more comments
     data_vec = vec(data)
     num_elements = length(data_vec)
     bytes_per_element = sizeof(T)
-    elements_per_block = max(1, div(VTK_COMPRESSION_BLOCK_SIZE, bytes_per_element))
+
+    # Aim for multiple blocks per threads to reduce variance in runtime between threads.
+    target_num_blocks = min(num_elements,
+                            VTK_COMPRESSION_BLOCKS_PER_THREAD * Threads.nthreads())
+
+    elements_per_block = cld(num_elements, target_num_blocks)
+
+    # Avoid absurdly small or large blocks that would lead to inefficient compression
+    # or inefficient multi-threading.
+    min_elements = max(1, cld(VTK_COMPRESSION_MIN_BLOCK_BYTES, bytes_per_element))
+    max_elements = max(1, div(VTK_COMPRESSION_MAX_BLOCK_BYTES, bytes_per_element))
+
+    elements_per_block = clamp(elements_per_block, min_elements, max_elements)
     num_blocks = cld(num_elements, elements_per_block)
 
     blocks = Vector{Vector{UInt8}}(undef, num_blocks)
     Threads.@threads for block in 1:num_blocks
         first_element = firstindex(data_vec) + (block - 1) * elements_per_block
         last_element = min(lastindex(data_vec), first_element + elements_per_block - 1)
+
+        # Create one buffer per block.
         buf = IOBuffer()
+
+        # Write compressed data.
         zWriter = ZlibCompressorStream(buf, level=compression_level, stop_on_end=true)
         write_array(zWriter, @view data_vec[first_element:last_element])
         write(zWriter, TranscodingStreams.TOKEN_END)
-        close(zWriter)
+        close(zWriter) # Release allocated resources (issue #43)
+
+        # Store compressed block in output array.
         blocks[block] = take!(buf)
         close(buf)
     end
@@ -152,10 +170,15 @@ function _compressed_blocks(data::DenseArray{T}, compression_level) where {T}
 end
 
 function _write_compressed_parallel(buf, data::DenseArray, compression_level)
+    # Compress individual blocks in parallel.
     blocks, blocksize, last_blocksize = _compressed_blocks(data, compression_level)
+
+    # Write the header.
     header = HeaderType.((length(blocks), blocksize, last_blocksize,
                           length.(blocks)...))
     write(buf, header...)
+
+    # Write compressed blocks in the expected order.
     foreach(block -> write(buf, block), blocks)
 
     nothing

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+ReadVTK = "dc215faf-f008-4882-a9f7-a79a826fadc3"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -1,0 +1,57 @@
+using WriteVTK
+using CodecZlib: ZlibDecompressorStream
+using Test
+
+function vtk_compressed_data(bytes)
+    io = IOBuffer(bytes)
+
+    num_blocks = Int(read(io, WriteVTK.HeaderType))
+    read(io, WriteVTK.HeaderType) # block size
+    read(io, WriteVTK.HeaderType) # last block size
+    block_sizes = [Int(read(io, WriteVTK.HeaderType)) for _ in 1:num_blocks]
+
+    data = UInt8[]
+    for block_size in block_sizes
+        block = read(io, block_size)
+        zReader = ZlibDecompressorStream(IOBuffer(block))
+        append!(data, read(zReader))
+        close(zReader)
+    end
+
+    data
+end
+
+function main()
+    data = collect(Float64, 1:200_000)
+    compression_level = 3
+
+    @test !WriteVTK._can_compress_in_parallel(Float64[])
+
+    data_buf = IOBuffer()
+    WriteVTK.write_array(data_buf, data)
+    data_bytes = take!(data_buf)
+
+    serial_buf = IOBuffer()
+    WriteVTK._write_compressed_serial(serial_buf, data, compression_level,
+                                      WriteVTK.sizeof_data(data))
+    @test vtk_compressed_data(take!(serial_buf)) == data_bytes
+
+    parallel_buf = IOBuffer()
+    WriteVTK._write_compressed_parallel(parallel_buf, data, compression_level)
+    @test vtk_compressed_data(take!(parallel_buf)) == data_bytes
+
+    mktempdir() do dir
+        files = vtk_grid(joinpath(dir, "parallel_compression"), 2, 2, 2;
+                         compress = compression_level,
+                         parallel_compression = true) do vtk
+            @test vtk.parallel_compression
+            vtk["values"] = reshape(collect(Float64, 1:8), 2, 2, 2)
+        end
+        @test length(files) == 1
+        @test isfile(files[1])
+    end
+
+    String[]
+end
+
+main()

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -34,10 +34,24 @@ function main()
     # |   100 MiB  |     1 MiB  |             100  |
     # |     1 GiB  |    ~1 MiB  |           ~1000  |
     # |   100 GiB  |  ~102 MiB  |            1000  |
+
+    # Test these expected block sizes:
+    # | Input Size | Block Size | Number of Blocks |
+    # |     2 MiB  |   128 KiB  |              16  |
+    # |    10 MiB  |   128 KiB  |              80  |
+    # |    25 MiB  |   256 KiB  |             100  |
+    # |   100 MiB  |     1 MiB  |             100  |
+    # |   500 MiB  |     1 MiB  |             500  |
+    # |     1 GiB  |    ~1 MiB  |           ~1000  |
+    # |    10 GiB  |   ~10 MiB  |            1000  |
+    # |   100 GiB  |  ~102 MiB  |            1000  |
     @test WriteVTK._compression_block_size(2MiB) == 128KiB
+    @test WriteVTK._compression_block_size(10MiB) == 128KiB
     @test WriteVTK._compression_block_size(25MiB) == 256KiB
     @test WriteVTK._compression_block_size(100MiB) == 1MiB
+    @test WriteVTK._compression_block_size(500MiB) == 1MiB
     @test WriteVTK._compression_block_size(1GiB) == cld(1GiB, 1000)
+    @test WriteVTK._compression_block_size(10GiB) == cld(10GiB, 1000)
     @test WriteVTK._compression_block_size(100GiB) == cld(100GiB, 1000)
 
     mktempdir() do dir

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -17,19 +17,32 @@ function num_compressed_blocks(filename)
     Int(read(io, WriteVTK.HeaderType))
 end
 
-# Mock the number of threads to be able to run this test on a single thread.
-WriteVTK.nthreads() = 4
-
 function main()
     dims = (200, 100, 10)
     data = reshape(collect(Float64, 1:prod(dims)), dims)
-    compression_level = 3
+
+    KiB = 1024
+    MiB = 1024 * KiB
+    GiB = 1024 * MiB
 
     @test !WriteVTK._can_compress_in_parallel(Float64[])
 
+    # Test these expected block sizes:
+    # | Input Size | Block Size | Number of Blocks |
+    # |     2 MiB  |   128 KiB  |              16  |
+    # |    25 MiB  |   256 KiB  |             100  |
+    # |   100 MiB  |     1 MiB  |             100  |
+    # |     1 GiB  |    ~1 MiB  |           ~1000  |
+    # |   100 GiB  |  ~102 MiB  |            1000  |
+    @test WriteVTK._compression_block_size(2MiB) == 128KiB
+    @test WriteVTK._compression_block_size(25MiB) == 256KiB
+    @test WriteVTK._compression_block_size(100MiB) == 1MiB
+    @test WriteVTK._compression_block_size(1GiB) == cld(1GiB, 1000)
+    @test WriteVTK._compression_block_size(100GiB) == cld(100GiB, 1000)
+
     mktempdir() do dir
         serial_files = vtk_grid(joinpath(dir, "serial_compression"), dims...;
-                                compress = compression_level) do vtk
+                                compress = true) do vtk
             vtk["values"] = data
         end
         @test length(serial_files) == 1
@@ -37,13 +50,15 @@ function main()
         @test read_values(serial_files[1], dims) == data
 
         parallel_files = vtk_grid(joinpath(dir, "parallel_compression"), dims...;
-                         compress = compression_level,
-                         parallel_compression = true) do vtk
+                         compress = true, parallel_compression = true) do vtk
             @test vtk.parallel_compression
             vtk["values"] = data
         end
         @test length(parallel_files) == 1
-        @test num_compressed_blocks(parallel_files[1]) == 16
+        field_size = sizeof(eltype(data)) * prod(dims)
+        @test field_size == 1_600_000
+        @test WriteVTK._compression_block_size(field_size) == 128KiB
+        @test num_compressed_blocks(parallel_files[1]) == 13 # cld(1_600_000, 128KiB) == 13
         @test read_values(parallel_files[1], dims) == data
     end
 

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -30,14 +30,6 @@ function main()
     # Test these expected block sizes:
     # | Input Size | Block Size | Number of Blocks |
     # |     2 MiB  |   128 KiB  |              16  |
-    # |    25 MiB  |   256 KiB  |             100  |
-    # |   100 MiB  |     1 MiB  |             100  |
-    # |     1 GiB  |    ~1 MiB  |           ~1000  |
-    # |   100 GiB  |  ~102 MiB  |            1000  |
-
-    # Test these expected block sizes:
-    # | Input Size | Block Size | Number of Blocks |
-    # |     2 MiB  |   128 KiB  |              16  |
     # |    10 MiB  |   128 KiB  |              80  |
     # |    25 MiB  |   256 KiB  |             100  |
     # |   100 MiB  |     1 MiB  |             100  |

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -1,54 +1,36 @@
 using WriteVTK
-using CodecZlib: ZlibDecompressorStream
+using ReadVTK
 using Test
 
-function vtk_compressed_data(bytes)
-    io = IOBuffer(bytes)
-
-    num_blocks = Int(read(io, WriteVTK.HeaderType))
-    read(io, WriteVTK.HeaderType) # block size
-    read(io, WriteVTK.HeaderType) # last block size
-    block_sizes = [Int(read(io, WriteVTK.HeaderType)) for _ in 1:num_blocks]
-
-    data = UInt8[]
-    for block_size in block_sizes
-        block = read(io, block_size)
-        zReader = ZlibDecompressorStream(IOBuffer(block))
-        append!(data, read(zReader))
-        close(zReader)
-    end
-
-    data
+function read_values(filename, dims)
+    vtk = ReadVTK.VTKFile(filename)
+    values = ReadVTK.get_point_data(vtk)["values"]
+    reshape(ReadVTK.get_data(values), dims)
 end
 
 function main()
-    data = collect(Float64, 1:200_000)
+    dims = (200, 100, 10)
+    data = reshape(collect(Float64, 1:prod(dims)), dims)
     compression_level = 3
 
     @test !WriteVTK._can_compress_in_parallel(Float64[])
 
-    data_buf = IOBuffer()
-    WriteVTK.write_array(data_buf, data)
-    data_bytes = take!(data_buf)
-
-    serial_buf = IOBuffer()
-    WriteVTK._write_compressed_serial(serial_buf, data, compression_level,
-                                      WriteVTK.sizeof_data(data))
-    @test vtk_compressed_data(take!(serial_buf)) == data_bytes
-
-    parallel_buf = IOBuffer()
-    WriteVTK._write_compressed_parallel(parallel_buf, data, compression_level)
-    @test vtk_compressed_data(take!(parallel_buf)) == data_bytes
-
     mktempdir() do dir
-        files = vtk_grid(joinpath(dir, "parallel_compression"), 2, 2, 2;
+        serial_files = vtk_grid(joinpath(dir, "serial_compression"), dims...;
+                                compress = compression_level) do vtk
+            vtk["values"] = data
+        end
+        @test length(serial_files) == 1
+        @test read_values(serial_files[1], dims) == data
+
+        parallel_files = vtk_grid(joinpath(dir, "parallel_compression"), dims...;
                          compress = compression_level,
                          parallel_compression = true) do vtk
             @test vtk.parallel_compression
-            vtk["values"] = reshape(collect(Float64, 1:8), 2, 2, 2)
+            vtk["values"] = data
         end
-        @test length(files) == 1
-        @test isfile(files[1])
+        @test length(parallel_files) == 1
+        @test read_values(parallel_files[1], dims) == data
     end
 
     String[]

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -8,6 +8,18 @@ function read_values(filename, dims)
     reshape(ReadVTK.get_data(values), dims)
 end
 
+function num_compressed_blocks(filename)
+    vtk = ReadVTK.VTKFile(filename)
+    values = ReadVTK.get_point_data(vtk)["values"]
+
+    io = IOBuffer(vtk.appended_data)
+    seek(io, values.offset)
+    Int(read(io, WriteVTK.HeaderType))
+end
+
+# Mock the number of threads to be able to run this test on a single thread.
+WriteVTK.nthreads() = 4
+
 function main()
     dims = (200, 100, 10)
     data = reshape(collect(Float64, 1:prod(dims)), dims)
@@ -21,6 +33,7 @@ function main()
             vtk["values"] = data
         end
         @test length(serial_files) == 1
+        @test num_compressed_blocks(serial_files[1]) == 1
         @test read_values(serial_files[1], dims) == data
 
         parallel_files = vtk_grid(joinpath(dir, "parallel_compression"), dims...;
@@ -30,6 +43,7 @@ function main()
             vtk["values"] = data
         end
         @test length(parallel_files) == 1
+        @test num_compressed_blocks(parallel_files[1]) == 16
         @test read_values(parallel_files[1], dims) == data
     end
 

--- a/test/compression.jl
+++ b/test/compression.jl
@@ -30,21 +30,21 @@ function main()
     # Test these expected block sizes:
     # | Input Size | Block Size | Number of Blocks |
     # |     2 MiB  |   128 KiB  |              16  |
-    # |    10 MiB  |   128 KiB  |              80  |
-    # |    25 MiB  |   256 KiB  |             100  |
-    # |   100 MiB  |     1 MiB  |             100  |
-    # |   500 MiB  |     1 MiB  |             500  |
-    # |     1 GiB  |    ~1 MiB  |           ~1000  |
-    # |    10 GiB  |   ~10 MiB  |            1000  |
-    # |   100 GiB  |  ~102 MiB  |            1000  |
+    # |    16 MiB  |   128 KiB  |             128  |
+    # |    32 MiB  |   256 KiB  |             128  |
+    # |   128 MiB  |     1 MiB  |             128  |
+    # |   512 MiB  |     1 MiB  |             512  |
+    # |     1 GiB  |     1 MiB  |            1024  |
+    # |    10 GiB  |    10 MiB  |            1024  |
+    # |   100 GiB  |   100 MiB  |            1024  |
     @test WriteVTK._compression_block_size(2MiB) == 128KiB
-    @test WriteVTK._compression_block_size(10MiB) == 128KiB
-    @test WriteVTK._compression_block_size(25MiB) == 256KiB
-    @test WriteVTK._compression_block_size(100MiB) == 1MiB
-    @test WriteVTK._compression_block_size(500MiB) == 1MiB
-    @test WriteVTK._compression_block_size(1GiB) == cld(1GiB, 1000)
-    @test WriteVTK._compression_block_size(10GiB) == cld(10GiB, 1000)
-    @test WriteVTK._compression_block_size(100GiB) == cld(100GiB, 1000)
+    @test WriteVTK._compression_block_size(16MiB) == 128KiB
+    @test WriteVTK._compression_block_size(32MiB) == 256KiB
+    @test WriteVTK._compression_block_size(128MiB) == 1MiB
+    @test WriteVTK._compression_block_size(512MiB) == 1MiB
+    @test WriteVTK._compression_block_size(1GiB) == 1MiB
+    @test WriteVTK._compression_block_size(10GiB) == 10MiB
+    @test WriteVTK._compression_block_size(100GiB) == 100MiB
 
     mktempdir() do dir
         serial_files = vtk_grid(joinpath(dir, "serial_compression"), dims...;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using SHA: sha1
 include("extent.jl")
 
 const tests = [
+    "compression.jl",
     "lagrange_hexahedron.jl",
     "surface.jl",
     "polyhedron_cube.jl",


### PR DESCRIPTION
When we run large simulations, we do so on machines with many CPU threads. We noticed that writing large VTK files takes a significant amount of time compared to the runtime of the actual simulation on these machines. We found that the culprit is not the actual write to disk but the compression that is applied by default.

The VTK format supports splitting appended data into multiple compressed blocks, but WriteVTK.jl currently uses a single block. This PR uses multiple blocks and compresses them in parallel, providing a significant speedup on large CPUs.

## Benchmark

The speedups below are computed on the compression cost itself: I subtracted the corresponding `compress=false` runtime first and then compare serial vs parallel compression.

### Intel Xeon w9-3475X, 36 threads, `256^3` Float32 data

| Compression level | Parallel time | Serial time | File size | Compression speedup |
|---:|---:|---:|---:|---:|
| none | 38.8 ms | 37.3 ms | 64.0 MiB | - |
| 1 | 156 ms | 1.74 s | 57.6 MiB | 14.5x |
| 3 | 181 ms | 1.93 s | 57.5 MiB | 13.3x |
| 6 (default) | 173 ms | 2.08 s | 57.3 MiB | 15.3x |
| 9 | 185 ms | 2.08 s | 57.3 MiB | 13.9x |

### 2 x AMD Epyc 9654, 192 threads, `512^3` Float32 data

| Compression level | Parallel time | Serial time | File size | Compression speedup |
|---:|---:|---:|---:|---:|
| none | 151 ms | 192 ms | 512.0 MiB | - |
| 1 | 752 ms | 16.3 s | 460.5 MiB | 26.9x |
| 3 | 758 ms | 17.7 s | 460.2 MiB | 28.8x |
| 6 (default) | 709 ms | 19.3 s | 458.1 MiB | 34.2x |
| 9 | 759 ms | 19.3 s | 458.1 MiB | 31.4x |

<details>
<summary>Benchmark code</summary>

```julia
using BenchmarkTools
using Printf
using WriteVTK

function write_file(path, data, compress, parallel_compression)
    vtk_grid(path, size(data)...; compress, parallel_compression) do vtk
        vtk["values"] = data
    end
end

compress_vec = (false, 1, 3, 6, 9)
dims = (512, 512, 512)

data = rand(Float32, dims)

println("mode,compression_level,seconds,bytes")

mktempdir() do dir
    for parallel_compression in (true, false)
        mode = parallel_compression ? "parallel" : "serial"
        for compress in compress_vec
            path = joinpath(dir, "compression_$(compress)_parallel_$(parallel_compression)")
            seconds = @belapsed write_file($path, $data, $compress, $parallel_compression)
            bytes = filesize(path * ".vti")
            @printf("%s,%d,%.6f,%d\n", mode, compress, seconds, bytes)
        end
    end
end
```

</details>

## Real-life benchmark

The motivation for this change was a postprocessing workflow for a simulation that took 14 hours on a large data center GPU. The postprocessing step interpolates simulation data and writes 500 VTK files.

With serial compression, this was estimated to take about 23 hours on the same machine, with compression as the bottleneck because interpolation is already parallel. With parallel compression, the postprocessing time is reduced to about 1.5 hours.

The benchmark below writes one representative file on 72 threads. Interpolation before the VTK export takes 3.25 s on average across these runs, so the VTK export is clearly the bottleneck with serial compression. For the parallel runs, I also reported the runtime of just the blockwise parallel compression to demonstrate that the compression is not the dominant part anymore (when enough threads are used).

| Compression level | Serial VTK export | Parallel VTK export | Parallel compression | File size | VTK export speedup |
|---:|---:|---:|---:|---:|---:|
| none | 4.04 s | - | - | 5,042.7 MiB | - |
| 1 | 77.1 s | 4.23 s | 1.38 s | 1,972.3 MiB | 18.2x |
| 3 | 90.3 s | 4.47 s | 1.50 s | 1,971.9 MiB | 20.2x |
| 6 (default) | 155 s | 5.44 s | 2.51 s | 1,960.4 MiB | 28.6x |